### PR TITLE
feat: allow custom DeepSeek base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # Get your OpenAI API key from: https://platform.openai.com/api-keys
 OPENAI_API_KEY=your_openai_api_key_here
 
+# Get your DeepSeek API key from: https://platform.deepseek.com/
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+# Optionally override the API base URL (default: https://api.deepseek.com)
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
+
 # Get your X.AI API key from: https://console.x.ai/
 XAI_API_KEY=your_xai_api_key_here
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [zen_web.webm](https://github.com/user-attachments/assets/851e3911-7f06-47c0-a4ab-a2601236697c)
 
 <div align="center">
-  <b>🤖 <a href="https://www.anthropic.com/claude-code">Claude Code</a> OR <a href="https://github.com/google-gemini/gemini-cli">Gemini CLI</a> OR <a href="https://github.com/openai/codex">Codex CLI</a> + [Gemini / OpenAI / Grok / OpenRouter / DIAL / Ollama / Anthropic / Any Model] = Your Ultimate AI Development Team</b>
+  <b>🤖 <a href="https://www.anthropic.com/claude-code">Claude Code</a> OR <a href="https://github.com/google-gemini/gemini-cli">Gemini CLI</a> OR <a href="https://github.com/openai/codex">Codex CLI</a> + [Gemini / OpenAI / DeepSeek / Grok / OpenRouter / DIAL / Ollama / Anthropic / Any Model] = Your Ultimate AI Development Team</b>
 </div>
 
 <br/>
@@ -85,6 +85,7 @@ For best results, use Claude Code with:
 - **[OpenRouter](https://openrouter.ai/)** - Access multiple models with one API
 - **[Gemini](https://makersuite.google.com/app/apikey)** - Google's latest models
 - **[OpenAI](https://platform.openai.com/api-keys)** - O3, GPT-5 series
+- **[DeepSeek](https://platform.deepseek.com/)** - DeepSeek V3.1 models
 - **[X.AI](https://console.x.ai/)** - Grok models
 - **[DIAL](https://dialx.ai/)** - Vendor-agnostic model access
 - **[Ollama](https://ollama.ai/)** - Local models (free)
@@ -204,6 +205,8 @@ DISABLED_TOOLS=
         // API configuration
         "GEMINI_API_KEY": "your-gemini-key",
         "OPENAI_API_KEY": "your-openai-key",
+        "DEEPSEEK_API_KEY": "your-deepseek-key",
+        "DEEPSEEK_BASE_URL": "https://api.deepseek.com",  // Optional custom endpoint
         "OPENROUTER_API_KEY": "your-openrouter-key",
         
         // Logging and performance

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,9 @@ This guide covers all configuration options for the Zen MCP Server. The server i
 DEFAULT_MODEL=auto
 GEMINI_API_KEY=your-gemini-key
 OPENAI_API_KEY=your-openai-key
+DEEPSEEK_API_KEY=your-deepseek-key
+# Optional: override DeepSeek API base URL
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
 ```
 
 ## Complete Configuration Reference
@@ -30,9 +33,15 @@ OPENAI_API_KEY=your-openai-key
 GEMINI_API_KEY=your_gemini_api_key_here
 # Get from: https://makersuite.google.com/app/apikey
 
-# OpenAI API  
+# OpenAI API
 OPENAI_API_KEY=your_openai_api_key_here
 # Get from: https://platform.openai.com/api-keys
+
+# DeepSeek API
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+# Get from: https://platform.deepseek.com/
+# Optional: override API base URL
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
 
 # X.AI GROK API
 XAI_API_KEY=your_xai_api_key_here
@@ -127,6 +136,10 @@ OPENROUTER_ALLOWED_MODELS=opus,sonnet,mistral
 - `gemini-2.5-pro` (1M context, powerful)
 - `flash` (shorthand for Flash model)
 - `pro` (shorthand for Pro model)
+
+**DeepSeek Models:**
+- `deepseek-chat` (128K context, chat)
+- `deepseek-reasoner` (128K context, reasoning with thinking tokens)
 
 **X.AI GROK Models:**
 - `grok-4-latest` (256K context, latest flagship model with reasoning, vision, and structured outputs)

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -38,6 +38,10 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # OpenAI
 OPENAI_API_KEY=your_openai_api_key_here
 
+# DeepSeek
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+# DEEPSEEK_BASE_URL=https://api.deepseek.com   # Optional: custom API endpoint
+
 # X.AI GROK
 XAI_API_KEY=your_xai_api_key_here
 
@@ -432,6 +436,8 @@ Configure Claude Desktop to use the containerized server. **Choose one of the co
 # At least one API key is required
 GEMINI_API_KEY=your_gemini_key
 OPENAI_API_KEY=your_openai_key
+DEEPSEEK_API_KEY=your_deepseek_key
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
 # ... other keys
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,6 +31,10 @@ You need at least one API key. Choose based on your needs:
 - Visit [OpenAI Platform](https://platform.openai.com/api-keys)
 - Generate an API key for O3, GPT-5 access
 
+**DeepSeek:**
+- Visit [DeepSeek Platform](https://platform.deepseek.com/)
+- Generate an API key for DeepSeek models
+
 **X.AI (Grok):**
 - Visit [X.AI Console](https://console.x.ai/)
 - Generate an API key for Grok models
@@ -199,8 +203,10 @@ nano .env
 Add your API keys (at least one required):
 ```env
 # Choose your providers (at least one required)
-GEMINI_API_KEY=your-gemini-api-key-here      # For Gemini models  
+GEMINI_API_KEY=your-gemini-api-key-here      # For Gemini models
 OPENAI_API_KEY=your-openai-api-key-here      # For O3, GPT-5
+DEEPSEEK_API_KEY=your-deepseek-api-key-here  # For DeepSeek models
+# DEEPSEEK_BASE_URL=https://api.deepseek.com   # Optional: custom API endpoint
 XAI_API_KEY=your-xai-api-key-here            # For Grok models
 OPENROUTER_API_KEY=your-openrouter-key       # For multiple models
 
@@ -349,6 +355,8 @@ CUSTOM_MODEL_NAME=llama3.2                   # Default model name
 DEFAULT_MODEL=auto
 GEMINI_API_KEY=your-key
 OPENAI_API_KEY=your-key
+DEEPSEEK_API_KEY=your-key
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
 GOOGLE_ALLOWED_MODELS=flash,pro
 OPENAI_ALLOWED_MODELS=o4-mini,o3-mini
 ```
@@ -360,11 +368,13 @@ GEMINI_API_KEY=your-key
 GOOGLE_ALLOWED_MODELS=flash
 ```
 
-### High-Performance Setup  
+### High-Performance Setup
 ```env
 DEFAULT_MODEL=auto
 GEMINI_API_KEY=your-key
 OPENAI_API_KEY=your-key
+DEEPSEEK_API_KEY=your-key
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
 GOOGLE_ALLOWED_MODELS=pro
 OPENAI_ALLOWED_MODELS=o3
 ```

--- a/docs/tools/listmodels.md
+++ b/docs/tools/listmodels.md
@@ -77,6 +77,8 @@ The available models depend on your configuration:
 **API Keys Required:**
 - `GEMINI_API_KEY` - Enables Gemini Pro and Flash models
 - `OPENAI_API_KEY` - Enables OpenAI O3, O4-mini, and GPT models
+- `DEEPSEEK_API_KEY` - Enables DeepSeek Chat and Reasoner models
+- `DEEPSEEK_BASE_URL` - (Optional) Custom DeepSeek API endpoint
 - `OPENROUTER_API_KEY` - Enables access to multiple providers through OpenRouter
 - `CUSTOM_API_URL` - Enables local/custom models (Ollama, vLLM, etc.)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,6 +38,8 @@ cat .env
 # Ensure at least one key is set:
 # GEMINI_API_KEY=your-key-here
 # OPENAI_API_KEY=your-key-here
+# DEEPSEEK_API_KEY=your-key-here
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
 ```
 
 If you need to update your API keys, edit the `.env` file and then restart Claude for changes to take effect.

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -5,6 +5,7 @@ from .gemini import GeminiModelProvider
 from .openai_compatible import OpenAICompatibleProvider
 from .openai_provider import OpenAIModelProvider
 from .openrouter import OpenRouterProvider
+from .deepseek import DeepSeekModelProvider
 from .registry import ModelProviderRegistry
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "GeminiModelProvider",
     "OpenAIModelProvider",
     "OpenAICompatibleProvider",
+    "DeepSeekModelProvider",
     "OpenRouterProvider",
 ]

--- a/providers/base.py
+++ b/providers/base.py
@@ -22,6 +22,7 @@ class ProviderType(Enum):
 
     GOOGLE = "google"
     OPENAI = "openai"
+    DEEPSEEK = "deepseek"
     XAI = "xai"
     OPENROUTER = "openrouter"
     CUSTOM = "custom"

--- a/providers/deepseek.py
+++ b/providers/deepseek.py
@@ -1,0 +1,138 @@
+"""DeepSeek model provider implementation."""
+
+from typing import Optional, TYPE_CHECKING
+import logging
+
+from .openai_compatible import OpenAICompatibleProvider
+from .base import (
+    ModelCapabilities,
+    ModelResponse,
+    ProviderType,
+    create_temperature_constraint,
+)
+
+if TYPE_CHECKING:
+    from tools.models import ToolModelCategory
+
+logger = logging.getLogger(__name__)
+
+
+class DeepSeekModelProvider(OpenAICompatibleProvider):
+    """Provider for DeepSeek's OpenAI-compatible API."""
+
+    FRIENDLY_NAME = "DeepSeek"
+
+    SUPPORTED_MODELS = {
+        "deepseek-chat": ModelCapabilities(
+            provider=ProviderType.DEEPSEEK,
+            model_name="deepseek-chat",
+            friendly_name="DeepSeek (Chat)",
+            context_window=128_000,
+            max_output_tokens=16_000,
+            supports_extended_thinking=False,
+            supports_system_prompts=True,
+            supports_streaming=True,
+            supports_function_calling=True,
+            supports_json_mode=True,
+            supports_images=False,
+            supports_temperature=True,
+            temperature_constraint=create_temperature_constraint("range"),
+            description="DeepSeek V3.1 chat model (non-reasoning mode)",
+            aliases=["deepseek", "chat"],
+        ),
+        "deepseek-reasoner": ModelCapabilities(
+            provider=ProviderType.DEEPSEEK,
+            model_name="deepseek-reasoner",
+            friendly_name="DeepSeek (Reasoner)",
+            context_window=128_000,
+            max_output_tokens=16_000,
+            supports_extended_thinking=True,
+            max_thinking_tokens=16_000,
+            supports_system_prompts=True,
+            supports_streaming=True,
+            supports_function_calling=True,
+            supports_json_mode=True,
+            supports_images=False,
+            supports_temperature=True,
+            temperature_constraint=create_temperature_constraint("range"),
+            description="DeepSeek V3.1 reasoning model with thinking tokens",
+            aliases=["reasoner"],
+        ),
+    }
+
+    def __init__(self, api_key: str, **kwargs):
+        """Initialize DeepSeek provider with API key and optional settings."""
+        kwargs.setdefault("base_url", "https://api.deepseek.com")
+        super().__init__(api_key, **kwargs)
+
+    def get_provider_type(self) -> ProviderType:
+        """Get the provider type."""
+        return ProviderType.DEEPSEEK
+
+    def get_capabilities(self, model_name: str) -> ModelCapabilities:
+        """Get capabilities for a specific DeepSeek model."""
+        if model_name in self.SUPPORTED_MODELS:
+            capabilities = self.SUPPORTED_MODELS[model_name]
+        else:
+            resolved_name = self._resolve_model_name(model_name)
+            capabilities = self.SUPPORTED_MODELS.get(resolved_name)
+            model_name = resolved_name
+
+        if not capabilities:
+            raise ValueError(f"Unsupported DeepSeek model: {model_name}")
+
+        from utils.model_restrictions import get_restriction_service
+
+        restriction_service = get_restriction_service()
+        if not restriction_service.is_allowed(ProviderType.DEEPSEEK, capabilities.model_name, model_name):
+            raise ValueError(f"DeepSeek model '{model_name}' is not allowed by restriction policy.")
+
+        return capabilities
+
+    def validate_model_name(self, model_name: str) -> bool:
+        """Validate if the model name is supported and allowed."""
+        resolved_name = self._resolve_model_name(model_name)
+        if resolved_name not in self.SUPPORTED_MODELS:
+            return False
+        from utils.model_restrictions import get_restriction_service
+
+        restriction_service = get_restriction_service()
+        if not restriction_service.is_allowed(ProviderType.DEEPSEEK, resolved_name, model_name):
+            logger.debug(
+                f"DeepSeek model '{model_name}' -> '{resolved_name}' blocked by restrictions"
+            )
+            return False
+        return True
+
+    def generate_content(
+        self,
+        prompt: str,
+        model_name: str,
+        system_prompt: Optional[str] = None,
+        temperature: float = 0.3,
+        max_output_tokens: Optional[int] = None,
+        **kwargs,
+    ) -> ModelResponse:
+        """Generate content using DeepSeek API with alias resolution."""
+        resolved_model_name = self._resolve_model_name(model_name)
+        return super().generate_content(
+            prompt=prompt,
+            model_name=resolved_model_name,
+            system_prompt=system_prompt,
+            temperature=temperature,
+            max_output_tokens=max_output_tokens,
+            **kwargs,
+        )
+
+    def supports_thinking_mode(self, model_name: str) -> bool:
+        """Check if the model supports extended thinking mode."""
+        resolved = self._resolve_model_name(model_name)
+        capabilities = self.SUPPORTED_MODELS.get(resolved)
+        return bool(capabilities and capabilities.supports_extended_thinking)
+
+    def get_preferred_model(self, category: "ToolModelCategory", allowed_models: list[str]) -> Optional[str]:
+        """Simple preference for DeepSeek models based on category."""
+        if not allowed_models:
+            return None
+        # Currently no special preferences beyond first allowed model
+        return allowed_models[0]

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -20,6 +20,7 @@ class ModelProviderRegistry:
     PROVIDER_PRIORITY_ORDER = [
         ProviderType.GOOGLE,  # Direct Gemini access
         ProviderType.OPENAI,  # Direct OpenAI access
+        ProviderType.DEEPSEEK,  # Direct DeepSeek access
         ProviderType.XAI,  # Direct X.AI GROK access
         ProviderType.DIAL,  # DIAL unified API access
         ProviderType.CUSTOM,  # Local/self-hosted models
@@ -96,8 +97,16 @@ class ModelProviderRegistry:
         else:
             if not api_key:
                 return None
-            # Initialize non-custom provider with just API key
-            provider = provider_class(api_key=api_key)
+            # Initialize non-custom provider, allowing optional base URL overrides
+            provider_kwargs = {"api_key": api_key}
+
+            if provider_type == ProviderType.DEEPSEEK:
+                base_url = os.getenv("DEEPSEEK_BASE_URL")
+                if base_url:
+                    provider_kwargs["base_url"] = base_url
+
+            # Initialize the provider with any additional kwargs
+            provider = provider_class(**provider_kwargs)
 
         # Cache the instance
         instance._initialized_providers[provider_type] = provider
@@ -232,6 +241,7 @@ class ModelProviderRegistry:
         key_mapping = {
             ProviderType.GOOGLE: "GEMINI_API_KEY",
             ProviderType.OPENAI: "OPENAI_API_KEY",
+            ProviderType.DEEPSEEK: "DEEPSEEK_API_KEY",
             ProviderType.XAI: "XAI_API_KEY",
             ProviderType.OPENROUTER: "OPENROUTER_API_KEY",
             ProviderType.CUSTOM: "CUSTOM_API_KEY",  # Can be empty for providers that don't need auth

--- a/server.py
+++ b/server.py
@@ -372,7 +372,7 @@ def configure_providers():
     Configure and validate AI providers based on available API keys.
 
     This function checks for API keys and registers the appropriate providers.
-    At least one valid API key (Gemini or OpenAI) is required.
+    At least one valid API key (Gemini, OpenAI, DeepSeek, etc.) is required.
 
     Raises:
         ValueError: If no valid API keys are found or conflicting configurations detected
@@ -389,6 +389,7 @@ def configure_providers():
     from providers.dial import DIALModelProvider
     from providers.gemini import GeminiModelProvider
     from providers.openai_provider import OpenAIModelProvider
+    from providers.deepseek import DeepSeekModelProvider
     from providers.openrouter import OpenRouterProvider
     from providers.xai import XAIModelProvider
     from utils.model_restrictions import get_restriction_service
@@ -417,6 +418,13 @@ def configure_providers():
             logger.debug("OpenAI API key not found in environment")
         else:
             logger.debug("OpenAI API key is placeholder value")
+
+    # Check for DeepSeek API key
+    deepseek_key = os.getenv("DEEPSEEK_API_KEY")
+    if deepseek_key and deepseek_key != "your_deepseek_api_key_here":
+        valid_providers.append("DeepSeek")
+        has_native_apis = True
+        logger.info("DeepSeek API key found - DeepSeek models available")
 
     # Check for X.AI API key
     xai_key = os.getenv("XAI_API_KEY")
@@ -469,6 +477,8 @@ def configure_providers():
             ModelProviderRegistry.register_provider(ProviderType.GOOGLE, GeminiModelProvider)
         if openai_key and openai_key != "your_openai_api_key_here":
             ModelProviderRegistry.register_provider(ProviderType.OPENAI, OpenAIModelProvider)
+        if deepseek_key and deepseek_key != "your_deepseek_api_key_here":
+            ModelProviderRegistry.register_provider(ProviderType.DEEPSEEK, DeepSeekModelProvider)
         if xai_key and xai_key != "your_xai_api_key_here":
             ModelProviderRegistry.register_provider(ProviderType.XAI, XAIModelProvider)
         if dial_key and dial_key != "your_dial_api_key_here":

--- a/tests/test_deepseek_provider.py
+++ b/tests/test_deepseek_provider.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock
+
+from providers.deepseek import DeepSeekModelProvider
+from providers.base import ProviderType
+from providers.registry import ModelProviderRegistry
+
+
+class TestDeepSeekProvider:
+    def test_provider_initialization(self):
+        provider = DeepSeekModelProvider(api_key="test-key")
+        assert provider.api_key == "test-key"
+        assert provider.get_provider_type() == ProviderType.DEEPSEEK
+        assert provider.base_url == "https://api.deepseek.com"
+
+    def test_registry_uses_env_base_url(self, monkeypatch):
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+        monkeypatch.setenv("DEEPSEEK_BASE_URL", "https://custom.local")
+        ModelProviderRegistry.register_provider(ProviderType.DEEPSEEK, DeepSeekModelProvider)
+        provider = ModelProviderRegistry.get_provider(ProviderType.DEEPSEEK, force_new=True)
+        assert provider.base_url == "https://custom.local"
+        ModelProviderRegistry.unregister_provider(ProviderType.DEEPSEEK)
+
+    def test_get_capabilities(self):
+        provider = DeepSeekModelProvider(api_key="test-key")
+        caps = provider.get_capabilities("deepseek-chat")
+        assert caps.provider == ProviderType.DEEPSEEK
+        assert caps.model_name == "deepseek-chat"
+
+    def test_model_shorthand_resolution(self):
+        provider = DeepSeekModelProvider(api_key="test-key")
+        assert provider.validate_model_name("chat")
+        caps = provider.get_capabilities("chat")
+        assert caps.model_name == "deepseek-chat"
+
+    def test_generate_content(self):
+        provider = DeepSeekModelProvider(api_key="test-key")
+        mock_client = Mock()
+        mock_client.chat.completions.create.return_value = Mock(
+            choices=[Mock(message=Mock(content="hello"), finish_reason="stop")],
+            model="deepseek-chat",
+            id="id",
+            created=123,
+            usage=Mock(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+        provider._client = mock_client
+
+        response = provider.generate_content(
+            prompt="hi", model_name="chat", system_prompt="system"
+        )
+        assert response.content == "hello"
+        assert response.model_name == "deepseek-chat"
+        assert response.provider == ProviderType.DEEPSEEK

--- a/utils/model_restrictions.py
+++ b/utils/model_restrictions.py
@@ -9,6 +9,7 @@ standardization purposes.
 Environment Variables:
 - OPENAI_ALLOWED_MODELS: Comma-separated list of allowed OpenAI models
 - GOOGLE_ALLOWED_MODELS: Comma-separated list of allowed Gemini models
+- DEEPSEEK_ALLOWED_MODELS: Comma-separated list of allowed DeepSeek models
 - XAI_ALLOWED_MODELS: Comma-separated list of allowed X.AI GROK models
 - OPENROUTER_ALLOWED_MODELS: Comma-separated list of allowed OpenRouter models
 - DIAL_ALLOWED_MODELS: Comma-separated list of allowed DIAL models
@@ -43,6 +44,7 @@ class ModelRestrictionService:
     ENV_VARS = {
         ProviderType.OPENAI: "OPENAI_ALLOWED_MODELS",
         ProviderType.GOOGLE: "GOOGLE_ALLOWED_MODELS",
+        ProviderType.DEEPSEEK: "DEEPSEEK_ALLOWED_MODELS",
         ProviderType.XAI: "XAI_ALLOWED_MODELS",
         ProviderType.OPENROUTER: "OPENROUTER_ALLOWED_MODELS",
         ProviderType.DIAL: "DIAL_ALLOWED_MODELS",


### PR DESCRIPTION
## Summary
- allow overriding DeepSeek API endpoint via `DEEPSEEK_BASE_URL`
- document DeepSeek configuration in `.env.example` and docs
- test registry initialization with custom base URL

## Testing
- `pytest tests/test_deepseek_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b16b9371588330b779aba7ad6e5acc