### PR TITLE
config: set gemini-2.5-pro as default model

### DIFF
--- a/conf/cli_clients/gemini.json
+++ b/conf/cli_clients/gemini.json
@@ -2,7 +2,8 @@
   "name": "gemini",
   "command": "gemini",
   "additional_args": [
-    "--yolo"
+    "--yolo",
+    "-m", "gemini-2.5-pro"
   ],
   "env": {},
   "roles": {


### PR DESCRIPTION
## Summary
- Force gemini CLI to use `gemini-2.5-pro` model instead of defaulting to `flash-lite`

## Changes
```json
"additional_args": [
  "--yolo",
  "-m", "gemini-2.5-pro"  // added
]
```