### PR TITLE
docs: add invocation examples to all skills

### DIFF
--- a/skills-optional/pal-analyze/SKILL.md
+++ b/skills-optional/pal-analyze/SKILL.md
@@ -54,6 +54,19 @@ Multi-step analysis process:
 
 JSON with analysis findings, architectural insights, and recommendations.
 
+## Invocation
+
+```bash
+# Start analysis (step 1)
+pal-analyze --step "Analyze codebase architecture" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue analysis (step 2+)
+pal-analyze --step "Examine dependencies" --step_number 2 --total_steps 4 --next_step_required true --findings "Found MVC pattern" --continuation_id "abc-123"
+
+# With specific analysis type
+pal-analyze --step "Security analysis" --step_number 1 --total_steps 3 --next_step_required true --findings "" --analysis_type security --relevant_files '["./src/auth.py"]'
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills-optional/pal-docgen/SKILL.md
+++ b/skills-optional/pal-docgen/SKILL.md
@@ -51,6 +51,16 @@ Multi-step documentation generation:
 
 JSON with generated documentation content and formatting suggestions.
 
+## Invocation
+
+```bash
+# Start documentation (step 1)
+pal-docgen --step "Analyze code structure" --step_number 1 --total_steps 4 --next_step_required true --findings "" --num_files_documented 0 --total_files_to_document 5 --relevant_files '["./src/main.py"]'
+
+# Continue documentation (step 2+)
+pal-docgen --step "Document functions" --step_number 2 --total_steps 4 --next_step_required true --findings "Found 10 functions" --num_files_documented 1 --total_files_to_document 5 --continuation_id "abc-123"
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills-optional/pal-refactor/SKILL.md
+++ b/skills-optional/pal-refactor/SKILL.md
@@ -55,6 +55,19 @@ Multi-step refactoring analysis:
 
 JSON with identified code smells, refactoring suggestions, and priority recommendations.
 
+## Invocation
+
+```bash
+# Start refactoring analysis (step 1)
+pal-refactor --step "Identify code smells" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue analysis (step 2+)
+pal-refactor --step "Analyze impact" --step_number 2 --total_steps 4 --next_step_required true --findings "Found duplicate code" --continuation_id "abc-123"
+
+# With specific refactor type
+pal-refactor --step "Find extraction opportunities" --step_number 1 --total_steps 3 --next_step_required true --findings "" --refactor_type extract --relevant_files '["./src/utils.py"]'
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills-optional/pal-secaudit/SKILL.md
+++ b/skills-optional/pal-secaudit/SKILL.md
@@ -57,6 +57,19 @@ Multi-step security audit:
 
 JSON with vulnerabilities found, severity levels, and remediation steps.
 
+## Invocation
+
+```bash
+# Start security audit (step 1)
+pal-secaudit --step "Define audit strategy" --step_number 1 --total_steps 5 --next_step_required true --findings ""
+
+# Continue audit (step 2+)
+pal-secaudit --step "Check authentication" --step_number 2 --total_steps 5 --next_step_required true --findings "JWT implementation found" --continuation_id "abc-123"
+
+# With specific focus
+pal-secaudit --step "OWASP Top 10 review" --step_number 1 --total_steps 4 --next_step_required true --findings "" --audit_focus owasp --relevant_files '["./src/api.py"]'
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills-optional/pal-testgen/SKILL.md
+++ b/skills-optional/pal-testgen/SKILL.md
@@ -52,6 +52,19 @@ Multi-step test generation:
 
 JSON with generated test code, test scenarios, and coverage recommendations.
 
+## Invocation
+
+```bash
+# Start test generation (step 1)
+pal-testgen --step "Analyze code functionality" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue (step 2+)
+pal-testgen --step "Identify edge cases" --step_number 2 --total_steps 4 --next_step_required true --findings "Found 5 public methods" --continuation_id "abc-123"
+
+# With file context
+pal-testgen --step "Generate unit tests" --step_number 1 --total_steps 3 --next_step_required true --findings "" --relevant_files '["./src/calculator.py"]'
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills-optional/pal-tracer/SKILL.md
+++ b/skills-optional/pal-tracer/SKILL.md
@@ -53,6 +53,19 @@ Multi-step tracing process:
 
 JSON with execution trace, call graph, and data flow analysis.
 
+## Invocation
+
+```bash
+# Start tracing (step 1)
+pal-tracer --step "Map call structure" --step_number 1 --total_steps 4 --next_step_required true --findings "" --target_description "Trace user login flow" --trace_mode static
+
+# Continue tracing (step 2+)
+pal-tracer --step "Trace data flow" --step_number 2 --total_steps 4 --next_step_required true --findings "Entry point: login()" --target_description "Trace user login flow" --trace_mode static --continuation_id "abc-123"
+
+# With file context
+pal-tracer --step "Analyze execution path" --step_number 1 --total_steps 3 --next_step_required true --findings "" --target_description "Order processing" --trace_mode data_flow --relevant_files '["./src/order.py"]'
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills/pal-apilookup/SKILL.md
+++ b/skills/pal-apilookup/SKILL.md
@@ -29,6 +29,16 @@ None - this is a simple single-prompt tool.
 
 JSON with documentation excerpts, usage examples, and relevant links.
 
+## Invocation
+
+```bash
+# Basic usage
+pal-apilookup --prompt "How to use React useEffect hook?"
+
+# SDK documentation
+pal-apilookup --prompt "Python requests library POST with JSON body"
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills/pal-challenge/SKILL.md
+++ b/skills/pal-challenge/SKILL.md
@@ -29,6 +29,16 @@ None - this is a simple single-prompt tool.
 
 JSON with challenges, counter-arguments, identified risks, and alternative perspectives.
 
+## Invocation
+
+```bash
+# Challenge a decision
+pal-challenge --prompt "We decided to use microservices. What could go wrong?"
+
+# Stress-test an approach
+pal-challenge --prompt "Is using MongoDB for this use case a good idea?"
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills/pal-chat/SKILL.md
+++ b/skills/pal-chat/SKILL.md
@@ -35,6 +35,19 @@ Collaborative thinking and development discussions with PAL's multi-model AI sup
 
 JSON response with AI analysis and optional `continuation_id` for follow-up conversations.
 
+## Invocation
+
+```bash
+# Basic usage
+pal-chat --prompt "How should I structure this API?"
+
+# With file context
+pal-chat --prompt "Review this code" --absolute_file_paths '["./src/main.py"]'
+
+# Continue conversation
+pal-chat --prompt "Tell me more" --continuation_id "abc-123"
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills/pal-clink/SKILL.md
+++ b/skills/pal-clink/SKILL.md
@@ -33,6 +33,22 @@ Connect to external AI command-line tools for cross-model collaboration. Enables
 
 JSON with external AI response and integration notes.
 
+## Invocation
+
+```bash
+# Call Gemini CLI
+pal-clink --cli_name gemini --prompt "Analyze this architecture"
+
+# Call Codex CLI
+pal-clink --cli_name codex --prompt "Review this code"
+
+# With file context
+pal-clink --cli_name gemini --prompt "Explain this" --absolute_file_paths '["./src/main.py"]'
+
+# Continue conversation
+pal-clink --cli_name gemini --prompt "More details" --continuation_id "abc-123"
+```
+
 ## Model Selection
 
 CLink uses external CLI tools (Gemini CLI, aider, etc.) rather than internal PAL models.

--- a/skills/pal-codereview/SKILL.md
+++ b/skills/pal-codereview/SKILL.md
@@ -55,6 +55,19 @@ Multi-step review process:
 
 JSON with review findings, severity levels, and guidance for next steps.
 
+## Invocation
+
+```bash
+# Start code review (step 1)
+pal-codereview --step "Initial code structure analysis" --step_number 1 --total_steps 5 --next_step_required true --findings "" --relevant_files '["./src/api.py"]'
+
+# Continue review (step 2+)
+pal-codereview --step "Security scan" --step_number 2 --total_steps 5 --next_step_required true --findings "Found input validation" --continuation_id "abc-123"
+
+# With specific focus
+pal-codereview --step "Performance review" --step_number 1 --total_steps 3 --next_step_required true --findings "" --review_type performance --focus_on "database queries"
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills/pal-consensus/SKILL.md
+++ b/skills/pal-consensus/SKILL.md
@@ -48,6 +48,16 @@ Multi-step consensus process:
 
 JSON with multi-model analysis, areas of agreement, disagreements, and synthesized recommendation.
 
+## Invocation
+
+```bash
+# Start consensus (step 1 - your analysis)
+pal-consensus --step "Evaluate REST vs GraphQL for our API" --step_number 1 --total_steps 4 --next_step_required true --findings "Initial analysis: REST is simpler but GraphQL offers flexibility" --models '["gemini-2.5-pro", "gpt-4o"]'
+
+# Continue (step 2+ - consult models)
+pal-consensus --step "Consulting model 1" --step_number 2 --total_steps 4 --next_step_required true --findings "" --continuation_id "abc-123"
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills/pal-debug/SKILL.md
+++ b/skills/pal-debug/SKILL.md
@@ -52,6 +52,19 @@ Multi-step debugging process:
 
 JSON with debugging findings, hypotheses, and recommended fixes.
 
+## Invocation
+
+```bash
+# Start debugging (step 1)
+pal-debug --step "Reproduce the null pointer exception" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue investigation (step 2+)
+pal-debug --step "Trace data flow" --step_number 2 --total_steps 4 --next_step_required true --findings "Exception occurs in processOrder()" --hypothesis "Input validation missing" --continuation_id "abc-123"
+
+# With file context
+pal-debug --step "Analyze error logs" --step_number 1 --total_steps 3 --next_step_required true --findings "" --relevant_files '["./src/order.py", "./logs/error.log"]'
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills/pal-listmodels/SKILL.md
+++ b/skills/pal-listmodels/SKILL.md
@@ -42,6 +42,13 @@ JSON response with:
 }
 ```
 
+## Invocation
+
+```bash
+# List all available models (no parameters needed)
+pal-listmodels
+```
+
 ## Notes
 
 - Models are detected at runtime based on your `.env` configuration

--- a/skills/pal-planner/SKILL.md
+++ b/skills/pal-planner/SKILL.md
@@ -49,6 +49,19 @@ Multi-step planning workflow:
 
 JSON with implementation plan, dependencies, and recommended execution order.
 
+## Invocation
+
+```bash
+# Start planning (step 1)
+pal-planner --step "Analyze requirements for user auth feature" --step_number 1 --total_steps 5 --next_step_required true
+
+# Continue planning (step 2+)
+pal-planner --step "Design database schema" --step_number 2 --total_steps 5 --next_step_required true --continuation_id "abc-123"
+
+# Create alternative branch
+pal-planner --step "Alternative: OAuth approach" --step_number 3 --total_steps 5 --next_step_required true --branch_id "oauth-approach" --is_branch_point true
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills/pal-precommit/SKILL.md
+++ b/skills/pal-precommit/SKILL.md
@@ -58,6 +58,19 @@ Multi-step validation process:
 
 JSON with validation results, issues found, and commit readiness assessment.
 
+## Invocation
+
+```bash
+# Start validation (step 1)
+pal-precommit --step "Review staged changes" --step_number 1 --total_steps 3 --next_step_required true --findings "" --path "/path/to/repo"
+
+# Continue validation (step 2+)
+pal-precommit --step "Check for security issues" --step_number 2 --total_steps 3 --next_step_required true --findings "Found 3 modified files" --continuation_id "abc-123"
+
+# With focus area
+pal-precommit --step "Validate changes" --step_number 1 --total_steps 2 --next_step_required true --findings "" --path "/path/to/repo" --focus_on "security"
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration

--- a/skills/pal-thinkdeep/SKILL.md
+++ b/skills/pal-thinkdeep/SKILL.md
@@ -52,6 +52,19 @@ Multi-step deep thinking process:
 
 JSON response with deep analysis results, findings, and workflow continuation guidance.
 
+## Invocation
+
+```bash
+# Start deep analysis (step 1)
+pal-thinkdeep --step "Analyze the authentication flow" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue analysis (step 2+)
+pal-thinkdeep --step "Examine token validation" --step_number 2 --total_steps 4 --next_step_required true --findings "Found JWT implementation" --continuation_id "abc-123"
+
+# With file context
+pal-thinkdeep --step "Review architecture" --step_number 1 --total_steps 3 --next_step_required true --findings "" --relevant_files '["./src/auth.py"]'
+```
+
 ## Model Selection
 
 - Models are detected at runtime based on your configuration


### PR DESCRIPTION
## Summary
Add explicit command invocation examples to all 17 skills to prevent Claude from misinterpreting the command format.

## Problem
Claude was incorrectly calling skills:
- ❌ `pal analyze --analysis-type ...` (space + hyphen in param)
- ✅ `pal-analyze --analysis_type ...` (hyphen in name + underscore in param)

## Solution
Added `## Invocation` section with bash examples to each SKILL.md showing:
- Correct command name format (`pal-chat`, not `pal chat`)
- Correct parameter format (`--step_number`, not `--step-number`)
- JSON array syntax with single quotes for shell

## Updated Skills (17)
**Core:** pal-chat, pal-clink, pal-apilookup, pal-challenge, pal-thinkdeep, pal-codereview, pal-consensus, pal-debug, pal-listmodels, pal-planner, pal-precommit

**Optional:** pal-analyze, pal-docgen, pal-refactor, pal-secaudit, pal-testgen, pal-tracer