### PR TITLE
docs: clarify model selection as auto by default

### DIFF
--- a/skills-optional/pal-analyze/SKILL.md
+++ b/skills-optional/pal-analyze/SKILL.md
@@ -69,6 +69,6 @@ pal-analyze --step "Security analysis" --step_number 1 --total_steps 3 --next_st
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-docgen/SKILL.md
+++ b/skills-optional/pal-docgen/SKILL.md
@@ -63,6 +63,6 @@ pal-docgen --step "Document functions" --step_number 2 --total_steps 4 --next_st
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-refactor/SKILL.md
+++ b/skills-optional/pal-refactor/SKILL.md
@@ -70,6 +70,6 @@ pal-refactor --step "Find extraction opportunities" --step_number 1 --total_step
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-secaudit/SKILL.md
+++ b/skills-optional/pal-secaudit/SKILL.md
@@ -72,6 +72,6 @@ pal-secaudit --step "OWASP Top 10 review" --step_number 1 --total_steps 4 --next
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-testgen/SKILL.md
+++ b/skills-optional/pal-testgen/SKILL.md
@@ -67,6 +67,6 @@ pal-testgen --step "Generate unit tests" --step_number 1 --total_steps 3 --next_
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-tracer/SKILL.md
+++ b/skills-optional/pal-tracer/SKILL.md
@@ -68,6 +68,6 @@ pal-tracer --step "Analyze execution path" --step_number 1 --total_steps 3 --nex
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-apilookup/SKILL.md
+++ b/skills/pal-apilookup/SKILL.md
@@ -41,6 +41,6 @@ pal-apilookup --prompt "Python requests library POST with JSON body"
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-challenge/SKILL.md
+++ b/skills/pal-challenge/SKILL.md
@@ -41,6 +41,6 @@ pal-challenge --prompt "Is using MongoDB for this use case a good idea?"
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-chat/SKILL.md
+++ b/skills/pal-chat/SKILL.md
@@ -50,6 +50,6 @@ pal-chat --prompt "Tell me more" --continuation_id "abc-123"
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-codereview/SKILL.md
+++ b/skills/pal-codereview/SKILL.md
@@ -70,6 +70,6 @@ pal-codereview --step "Performance review" --step_number 1 --total_steps 3 --nex
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-consensus/SKILL.md
+++ b/skills/pal-consensus/SKILL.md
@@ -60,6 +60,6 @@ pal-consensus --step "Consulting model 1" --step_number 2 --total_steps 4 --next
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Provide `models` array to specify which models to consult
+- Default: auto - System automatically selects the best available model
+- Provide `models` array to specify which models to consult for consensus
+- Use `pal-listmodels` to see available model names first

--- a/skills/pal-debug/SKILL.md
+++ b/skills/pal-debug/SKILL.md
@@ -67,6 +67,6 @@ pal-debug --step "Analyze error logs" --step_number 1 --total_steps 3 --next_ste
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-planner/SKILL.md
+++ b/skills/pal-planner/SKILL.md
@@ -64,6 +64,6 @@ pal-planner --step "Alternative: OAuth approach" --step_number 3 --total_steps 5
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-precommit/SKILL.md
+++ b/skills/pal-precommit/SKILL.md
@@ -73,6 +73,6 @@ pal-precommit --step "Validate changes" --step_number 1 --total_steps 2 --next_s
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-thinkdeep/SKILL.md
+++ b/skills/pal-thinkdeep/SKILL.md
@@ -67,6 +67,6 @@ pal-thinkdeep --step "Review architecture" --step_number 1 --total_steps 3 --nex
 
 ## Model Selection
 
-- Models are detected at runtime based on your configuration
-- Use `pal-listmodels` to see available models before specifying one
-- Default: auto-select best available model for the task
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first


### PR DESCRIPTION
## Summary
- Update all SKILL.md files to emphasize that model selection defaults to auto
- Clarify that users should NOT specify `--model` unless necessary
- Let the system auto-select the best available model

## Changes
- 15 SKILL.md files updated (skills/ and skills-optional/)
- Model Selection section now clearly states:
  - **Default: auto** - System automatically selects the best available model
  - **Do NOT specify `--model` unless you have a specific reason**
  - If you must specify, use `pal-listmodels` to see available model names first

## Why
This helps Claude Code understand that it should not attempt to guess model names (like `--model gemini`) when calling skills. Instead, let the system auto-select the appropriate model.

## Test plan
- [ ] Reinstall skills with `./install-skills.sh`
- [ ] Verify Claude Code no longer attempts to specify model when not needed